### PR TITLE
Added support for GitRepository in YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ forges:
     - Directory: /var/lib/other-modules
     - Source: /var/code/puppetlabs-apache
     - Proxy: http://forge.puppetlabs.com
+    - GitRepository:
+        - http://github.com/example/puppetlabs-apache-fork.git
+        - "[0-9.]+"
 ```
 
 ## Running with Phusion Passenger (EXPERIMENTAL)

--- a/lib/puppet_library/puppet_library.rb
+++ b/lib/puppet_library/puppet_library.rb
@@ -108,14 +108,14 @@ module PuppetLibrary
                 options[:forges].each do |(forge_type, config)|
                     if forge_type == Forge::GitRepository
                         forge :git_repository do
-                          source config[0]
-                          include_tags Regexp.new config[1]
+                            source config[0]
+                            include_tags Regexp.new config[1]
                         end
                     else
-                    forge forge_type.new(*config)
+                        forge forge_type.new(*config)
+                    end
                 end
             end
-        end
         end
 
         def announce_server_start(options)

--- a/lib/puppet_library/puppet_library.rb
+++ b/lib/puppet_library/puppet_library.rb
@@ -106,9 +106,16 @@ module PuppetLibrary
 
             Server.configure do
                 options[:forges].each do |(forge_type, config)|
+                    if forge_type == Forge::GitRepository
+                        forge :git_repository do
+                          source config[0]
+                          include_tags Regexp.new config[1]
+                        end
+                    else
                     forge forge_type.new(*config)
                 end
             end
+        end
         end
 
         def announce_server_start(options)


### PR DESCRIPTION
Hi. This tool was exactly what I was looking for, but I didn't want to install Phusion Passenger to get Git support, so I modified the code to support Git repositories with the YAML configuration. I've tested it locally and it's running fine on my side.