### PR TITLE
Fixed CSS issue with search bar

### DIFF
--- a/lib/puppet_library/app/views/layout.haml
+++ b/lib/puppet_library/app/views/layout.haml
@@ -64,7 +64,7 @@
               %a{:href => '/'} Modules
             %li
               %a{:href => 'https://github.com/drrb/puppet-library', :target => "puppet-library"} Help
-          %form#module-search.navbar-form.navbar-right.form-search{ :action => "/", :method => "get", :role => "form" }
+          %form#module-search.navbar-form.form-search{ :action => "/", :method => "get", :role => "form" }
             .input-group
               %input.form-control.search-query{ :name => "search", :type => "search", :placeholder => "Search modules" }
               %span.input-group-btn


### PR DESCRIPTION
The search bar is displayed _under_ navigation bar. This fix replace the search bar _into_ the navigation bar. 

Now : 
![screen shot 2015-04-22 at 10 16 27](https://cloud.githubusercontent.com/assets/739192/7270012/190ee374-e8d9-11e4-9102-f23d87f6e511.png)

With this PR : 
![screen shot 2015-04-22 at 10 16 14](https://cloud.githubusercontent.com/assets/739192/7270015/2163f41a-e8d9-11e4-82d3-c6147808bbbe.png)
